### PR TITLE
force path constants to use CWD

### DIFF
--- a/optimization_program/run_script.py
+++ b/optimization_program/run_script.py
@@ -17,7 +17,7 @@ class OptimizationExecution:
     @staticmethod
     def run_opt_single_mode(game_config, mode, threads):
         """Create setup txt file for a single mode and run Rust executable binary."""
-        filename = os.path.join("library", "configs", "math_config.json")
+        filename = os.path.join(PATH_TO_GAMES, game_config.game_id, "library", "configs", "math_config.json")
         opt_config = OptimizationExecution.load_math_config(filename)
 
         opt_config = game_config.opt_params
@@ -65,10 +65,7 @@ class OptimizationExecution:
             text=True,
             cwd=OPTIMIZATION_PATH,
             check=True,
-            env={
-                **os.environ,
-                "PATH": updated_path
-            }
+            env={**os.environ, "PATH": updated_path},
         )
         if result.returncode == 0:
             print(result.stdout)

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -1,7 +1,8 @@
 """Set standard gamestate configuration with default values."""
 
-import os
 from src.config.betmode import BetMode
+from src.config.paths import PATH_TO_GAMES
+import os
 
 
 class Config:
@@ -140,8 +141,8 @@ class Config:
     def construct_paths(self, game_id: str) -> None:
         """Assign all output file paths"""
         assert len(game_id.split("_")) == 3, "provider_gameNumber_rtp"
-        self.reels_path = "reels"
-        self.library_path = "library"
+        self.reels_path = os.path.join(PATH_TO_GAMES, self.game_id, "reels")
+        self.library_path = os.path.join(PATH_TO_GAMES, self.game_id, "library")
 
     def check_folder_exists(self, folder_path: str) -> None:
         """Check if target folder exists, and create if it does not."""

--- a/src/config/paths.py
+++ b/src/config/paths.py
@@ -2,10 +2,9 @@
 
 import os
 
-ABS_PATH = os.path.abspath(os.path.join("..", ""))
-PROJECT_PATH = os.path.abspath(os.path.join("..", ".."))
+ABS_PATH = os.path.abspath(os.getcwd())
+PROJECT_PATH = os.path.abspath(os.getcwd())
 PATH_TO_ENGINE = PROJECT_PATH
 PATH_TO_GAMES = os.path.join(PROJECT_PATH, "games")
 OPTIMIZATION_PATH = os.path.join(PROJECT_PATH, "optimization_program")
 SETUP_PATH = os.path.join(OPTIMIZATION_PATH, "src", "setup.txt")
-

--- a/src/write_data/write_configs.py
+++ b/src/write_data/write_configs.py
@@ -271,9 +271,7 @@ def make_fe_config(gamestate, json_padding=True, assign_properties=True, **kwarg
     elif not json_padding:
         json_info["paddingReels"] = gamestate.config.paddingReels
 
-    f_name = os.path.join(
-        gamestate.output_files.config_path, f"config_fe_{gamestate.config.game_id}.json"
-    )
+    f_name = os.path.join(gamestate.output_files.config_path, f"config_fe_{gamestate.config.game_id}.json")
     fe_json = open(f_name, "w", encoding="UTF-8")
     fe_json.write(json.dumps(json_info, indent=4))
     fe_json.close()
@@ -304,7 +302,7 @@ def make_be_config(gamestate):
     be_info["providerNumber"] = int(config.provider_number)
     be_info["standardForceFile"] = {
         "file": "force.json",
-        "sha256": get_hash(str.join("/", [gamestate.output_files.force_path, "force.json"])),
+        "sha256": get_hash(os.path.join(gamestate.output_files.force_path, "force.json")),
     }
 
     # Betmode specific data

--- a/utils/game_analytics/get_pay_splits.py
+++ b/utils/game_analytics/get_pay_splits.py
@@ -1,12 +1,14 @@
+from src.config.paths import PATH_TO_GAMES
 from collections import defaultdict
 import os
+
 
 def get_unoptimized_hits(lut_path, all_modes, win_ranges):
     """Calculate hit-rates of simulation output lookup table."""
     all_modes_base_dist = defaultdict(lambda: defaultdict(int))
     total_mode_count = {}
     for mode in all_modes:
-        base_lut_file = lut_path + "/lookUpTable_" + str(mode) + ".csv"
+        base_lut_file = os.path.join(lut_path, "lookUpTable_" + str(mode) + ".csv")
         lut = open(base_lut_file, "r", encoding="UTF-8")
         counter = 0
         for line in lut:
@@ -132,7 +134,9 @@ def return_hit_rates(all_mode_distributions, total_weight, win_ranges):
 
 def return_all_filepaths(game_id: str, mode: str):
     """Return file files required for PAR sheet generation."""
-    lut_path = os.path.join("library", "lookup_tables", f"lookUpTable_{mode}_0.csv")
-    split_path = os.path.join("library", "lookup_tables", f"lookUpTableSegmented_{mode}.csv")
+    lut_path = os.path.join(PATH_TO_GAMES, game_id, "library", "lookup_tables", f"lookUpTable_{mode}_0.csv")
+    split_path = os.path.join(
+        PATH_TO_GAMES, game_id, "library", "lookup_tables", f"lookUpTableSegmented_{mode}.csv"
+    )
 
     return lut_path, split_path

--- a/utils/game_analytics/get_symbol_hits.py
+++ b/utils/game_analytics/get_symbol_hits.py
@@ -2,7 +2,6 @@
 
 import json
 import os
-
 from src.config.paths import PATH_TO_GAMES
 
 
@@ -133,7 +132,7 @@ def construct_symbol_probabilities(config, modes_to_analyse: list) -> type:
     """Find hit-rates of all symbol combinations."""
     check_file = []
     for mode in modes_to_analyse:
-        force_file = os.path.join("library", "forces", f"force_record_{mode}.json")
+        force_file = os.path.join(config.library_path, "forces", f"force_record_{mode}.json")
         check_file.append(os.path.isfile(force_file))
     if not all(check_file):
         raise RuntimeError("Force File Does Not Exist.")
@@ -149,7 +148,7 @@ def construct_custom_key_probabilities(config, modes_to_analyse, custom_search) 
     """Analyze win information from user defined search keys."""
     check_file = []
     for mode in modes_to_analyse:
-        force_file = os.path.join("library", "forces", f"force_record_{mode}.json")
+        force_file = os.path.join(config.library_path, "forces", f"force_record_{mode}.json")
         check_file.append(os.path.isfile(force_file))
     if not all(check_file):
         raise RuntimeError("Force File Does Not Exist.")


### PR DESCRIPTION
When defining PATH constants in src/config/paths.py - setup and project paths get the absolute path relative to os.getcwd()
-Tools such as config and PAR sheet generation assume <...>/math-sdk/ as the execution directory