### PR TITLE
fix: multiplier strategy 'combined' does not apply global_multiplier …

### DIFF
--- a/src/wins/multiplier_strategy.py
+++ b/src/wins/multiplier_strategy.py
@@ -46,4 +46,4 @@ def apply_combined_mult(
 ) -> tuple:
     """Apply symbol multipliers and then global multiplier"""
     win, sym_mult = apply_added_symbol_mult(board, win_amount, positions, multiplier_key)
-    return (win, sym_mult * global_multiplier)
+    return (win * global_multiplier  , sym_mult * global_multiplier)


### PR DESCRIPTION
Found issue while using multiplier strategy 'combined'.

combined strategy does not apply global_multiplier to win amount.
when combined multiplier strategy is used both global and symbol multiplier should be applied.