### PR TITLE
add devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,36 @@
+{
+  "name": "math-sdk Container",
+  "image": "mcr.microsoft.com/devcontainers/python:3.12",
+  
+  // Features to add to the dev container
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/rust:1": {}
+  },
+
+  // Configure tool-specific properties
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.pylint",
+        "ms-python.black-formatter",
+        "ms-toolsai.jupyter"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "python.formatting.provider": "black"
+      }
+    }
+  },
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally
+  // "forwardPorts": [8000, 5000],
+
+  // Use 'postCreateCommand' to run commands after the container is created
+  "postCreateCommand": "make setup",
+
+  // Set the default user to vscode (non-root)
+  "remoteUser": "vscode"
+}


### PR DESCRIPTION
### Summary

This PR adds a .devcontainer.json to support development in a standardized container-based environment.

### Why

- Ensures consistent tooling across machines
- Speeds up onboarding by preconfiguring dependencies
- Enables easy use with VS Code Dev Containers and GitHub Codespaces
- Reduces local setup issues and config drift


This is a minimal setup to start and can evolve as team needs grow.