### PR TITLE
fix force key override

### DIFF
--- a/src/state/state.py
+++ b/src/state/state.py
@@ -163,7 +163,7 @@ class GeneralGameState(ABC):
             ):
                 self.recorded_events[description]["timesTriggered"] += 1
                 self.recorded_events[description]["bookIds"] += [book_id]
-            else:
+            elif description not in self.recorded_events:
                 self.check_force_keys(description)
                 self.recorded_events[description] = {
                     "timesTriggered": 1,


### PR DESCRIPTION
If identical gamestate.record instances occur within the same simulation - the key used in the force_record file is inadvertently reset. 
force_record keys are not only initialized if the key description does not already exist. 