### PR TITLE
Bug fix: single thread multi-repeat fix

### DIFF
--- a/src/state/run_sims.py
+++ b/src/state/run_sims.py
@@ -152,16 +152,16 @@ def run_multi_process_sims(
             )
         elif threads == 1:
             gamestate.run_sims(
-                all_betmode_configs,
-                betmode,
-                sim_allocation,
-                threads,
-                num_repeats,
-                sims_per_thread,
-                0,
-                repeat,
-                compress,
-                write_event_list,
+                betmode_copy_list=all_betmode_configs,
+                betmode=betmode,
+                sim_to_criteria=sim_allocation,
+                total_threads=threads,
+                total_repeats=num_repeats,
+                num_sims=sims_per_thread,
+                thread_index=0,
+                repeat_count=repeat,
+                compress=compress,
+                write_event_list=write_event_list,
             )
         else:
             for thread in range(threads):

--- a/src/state/state.py
+++ b/src/state/state.py
@@ -232,6 +232,7 @@ class GeneralGameState(ABC):
     ) -> None:
         """Assigns criteria and runs individual simulations. Results are stored in temporary file to be combined when all threads are finished."""
         self.win_manager = WinManager(self.config.basegame_type, self.config.freegame_type)
+        self.library = {}
         self.betmode = betmode
         self.num_sims = num_sims
         for sim in range(


### PR DESCRIPTION
Gamestate library is reset for each 'repeat' when writing simulations within state.py. When using thread=1 and a batching-size < num_sims, simulation results from previous runs were written to the books_result file. 