### PR TITLE
Ways calculation

### DIFF
--- a/tests/win_calculations/test_wayspay.py
+++ b/tests/win_calculations/test_wayspay.py
@@ -50,7 +50,7 @@ def gamestate():
 
 
 def test_basic_ways(gamestate):
-    totalWays = len(gamestate.board[0]) ** len(gamestate.board)  # Assume all reels have equal rows
+    totalWays = len(gamestate.board[0]) ** len(gamestate.board)
     for idx, _ in enumerate(gamestate.board):
         for idy, _ in enumerate(gamestate.board[idx]):
             if idx < len(gamestate.board) - 1:
@@ -88,12 +88,10 @@ def setup_test_board(gamestate, symbol_name="H1", wild_mults=(2, 3)):
     """Setup a 3x3 board with H1s on reels 0 and 2, and wilds with multipliers on reel 1."""
     create_non_winning_board(gamestate)
 
-    # Place base symbols
     gamestate.board[0][0] = gamestate.create_symbol(symbol_name)
     gamestate.board[2][0] = gamestate.create_symbol(symbol_name)
     gamestate.board[2][1] = gamestate.create_symbol(symbol_name)
 
-    # Place wilds with specified multipliers
     for i, mult in enumerate(wild_mults):
         wild = gamestate.create_symbol("W")
         setattr(wild, "multiplier", mult)
@@ -116,17 +114,10 @@ def test_global_multiplier_strategy(gamestate):
     board = setup_test_board(gamestate, wild_mults=(2, 2))
     windata = Ways.get_ways_data(config=gamestate.config, board=board, multiplier_strategy="global")
 
-    expected_ways = 1 * 2 * 2  # wilds only count as 2 positions, not inflated
+    expected_ways = 1 * 2 * 2
     base_win = gamestate.config.paytable[(3, "H1")] * expected_ways
     global_mult = 2 + 2  # 4x total multiplier (additive)
 
     expected_win = base_win * global_mult
 
     assert windata["totalWin"] == expected_win, f"Expected {expected_win}, got {windata['totalWin']}"
-
-
-if __name__ == "__main__":
-
-    gs = create_test_ways_gamestate()
-    test_symbol_multiplier_strategy(gs)
-    test_global_multiplier_strategy(gs)

--- a/tests/win_calculations/test_wayspay.py
+++ b/tests/win_calculations/test_wayspay.py
@@ -23,6 +23,7 @@ class GameWaysConfig:
             (5, "H2"): 30,
             (4, "H2"): 20,
             (3, "H2"): 10,
+            (100, "X"): 0,
         }
 
         self.special_symbols = {"wild": ["W"], "scatter": ["S"], "blank": ["X"]}
@@ -31,7 +32,7 @@ class GameWaysConfig:
         self.freegame_type = "freegame"
 
 
-def create_test_lines_gamestate():
+def create_test_ways_gamestate():
     """Boilerplate gamestate for testing."""
     test_config = GameWaysConfig()
     test_gamestate = GamestateTest(test_config)
@@ -45,7 +46,7 @@ def create_test_lines_gamestate():
 @pytest.fixture
 def gamestate():
     """Initialise test state."""
-    return create_test_lines_gamestate()
+    return create_test_ways_gamestate()
 
 
 def test_basic_ways(gamestate):
@@ -75,3 +76,57 @@ def test_mixed_ways(gamestate):
     assert windata["wins"][0]["meta"]["ways"] == sym2Ways
     assert windata["wins"][1]["meta"]["ways"] == sym1Ways
     assert windata["totalWin"] == windata["wins"][0]["win"] + windata["wins"][1]["win"]
+
+
+def create_non_winning_board(gamestate):
+    for idx, _ in enumerate(gamestate.board):
+        for idy, _ in enumerate(gamestate.board[idx]):
+            gamestate.board[idx][idy] = gamestate.create_symbol("X")
+
+
+def setup_test_board(gamestate, symbol_name="H1", wild_mults=(2, 3)):
+    """Setup a 3x3 board with H1s on reels 0 and 2, and wilds with multipliers on reel 1."""
+    create_non_winning_board(gamestate)
+
+    # Place base symbols
+    gamestate.board[0][0] = gamestate.create_symbol(symbol_name)
+    gamestate.board[2][0] = gamestate.create_symbol(symbol_name)
+    gamestate.board[2][1] = gamestate.create_symbol(symbol_name)
+
+    # Place wilds with specified multipliers
+    for i, mult in enumerate(wild_mults):
+        wild = gamestate.create_symbol("W")
+        setattr(wild, "multiplier", mult)
+        gamestate.board[1][i] = wild
+
+    return gamestate.board
+
+
+def test_symbol_multiplier_strategy(gamestate):
+    board = setup_test_board(gamestate, wild_mults=(2, 3))
+    windata = Ways.get_ways_data(config=gamestate.config, board=board, multiplier_strategy="symbol")
+
+    expected_ways = 1 * (2 + 3) * 2  # H1 * wild counts as 5 symbols * 2 = 10 ways
+    expected_win = gamestate.config.paytable[(3, "H1")] * expected_ways
+
+    assert windata["totalWin"] == expected_win, f"Expected {expected_win}, got {windata['totalWin']}"
+
+
+def test_global_multiplier_strategy(gamestate):
+    board = setup_test_board(gamestate, wild_mults=(2, 2))
+    windata = Ways.get_ways_data(config=gamestate.config, board=board, multiplier_strategy="global")
+
+    expected_ways = 1 * 2 * 2  # wilds only count as 2 positions, not inflated
+    base_win = gamestate.config.paytable[(3, "H1")] * expected_ways
+    global_mult = 2 + 2  # 4x total multiplier (additive)
+
+    expected_win = base_win * global_mult
+
+    assert windata["totalWin"] == expected_win, f"Expected {expected_win}, got {windata['totalWin']}"
+
+
+if __name__ == "__main__":
+
+    gs = create_test_ways_gamestate()
+    test_symbol_multiplier_strategy(gs)
+    test_global_multiplier_strategy(gs)


### PR DESCRIPTION
Corrected ways calculation for when using symbol multiplier strategy on symbols.
The previous version of the ways calculation function incorrectly added the number of symbols with multipliers to the ways calculation in addition to the multipliers.

Now if There is a board:
X W(2x) X
S W(3x) S
There would be 1 * (2 + 3) * 1 ways. Where the 2x and 3x multipliers essentially act as there being 2/2 symbols in that position. 

Added the option to have a global multiplier strategy as an optional parameter. Where multiplier values on winning positions are added and applied to the final win. 