### PR TITLE
Ways update

### DIFF
--- a/src/calculations/ways.py
+++ b/src/calculations/ways.py
@@ -19,7 +19,7 @@ class Ways:
         config: Config,
         board: list[list[Symbol]],
         wild_key: str = "wild",
-        global_mult: int = 1,
+        global_multiplier: int = 1,
         multiplier_key: str = "multiplier",
         multiplier_strategy: str = "symbol",
     ):
@@ -79,7 +79,9 @@ class Ways:
 
                     if len(wilds[reel]) > 0:
                         for sym in wilds[reel]:
-                            if board[sym["reel"]][sym["row"]].check_attribute(multiplier_key):
+                            if board[sym["reel"]][sym["row"]].check_attribute(
+                                multiplier_key
+                            ) and multiplier_strategy in ["board", "symbol"]:
                                 wild_mult_val = board[sym["reel"]][sym["row"]].get_attribute(multiplier_key)
                                 cumulative_sym_mult += wild_mult_val * (wild_mult_val > 1)
                                 if multiplier_strategy == "board":
@@ -97,9 +99,9 @@ class Ways:
 
             match multiplier_strategy:
                 case "global":
-                    win_multiplier = global_mult
+                    win_multiplier = global_multiplier
                 case "board":
-                    win_multiplier = board_mult_count
+                    win_multiplier = max(board_mult_count, 1)
                 case "symbol":
                     win_multiplier = 1
 

--- a/tests/win_calculations/test_wayspay.py
+++ b/tests/win_calculations/test_wayspay.py
@@ -121,3 +121,18 @@ def test_board_multiplier_strategy(gamestate):
     expected_win = base_win * global_mult
 
     assert windata["totalWin"] == expected_win, f"Expected {expected_win}, got {windata['totalWin']}"
+
+
+def test_global_multiplier_strategy(gamestate):
+    global_mult = 5
+    board = setup_test_board(gamestate, wild_mults=(2, 2))
+    windata = Ways.get_ways_data(
+        config=gamestate.config, board=board, global_multiplier=global_mult, multiplier_strategy="global"
+    )
+
+    expected_ways = 1 * 2 * 2
+    base_win = gamestate.config.paytable[(3, "H1")] * expected_ways
+
+    expected_win = base_win * global_mult
+
+    assert windata["totalWin"] == expected_win, f"Expected {expected_win}, got {windata['totalWin']}"


### PR DESCRIPTION
Update to include global multiplier case for Way wins calculation:

- "global" : if using this strategy you can pass in an integer "global_multiplier" variable. Which will multiply each symbol win by the given value (default to 1)
- "symbol": Multiplies the 'number of ways' by a multiplier value attached to a given symbol 
- "board": scales the win-amount by the sum of multipliers attached to a winning symbol

Updated tests to include this additional case. 