### PR TITLE
fix: ensure all distribution keys match criteria list

### DIFF
--- a/optimization_program/optimization_config.py
+++ b/optimization_program/optimization_config.py
@@ -164,7 +164,7 @@ def verify_optimization_input(game_config, opt_dict):
         for dist in bm._distributions:
             dist_keys.append(dist._criteria)
 
-        assert [x in criteria_list for x in dist_keys], "Distribution criteria must match 'conditions' keys"
+        assert all(x in criteria_list for x in dist_keys), "Distribution criteria must match 'conditions' keys"
 
         # Verify optimization segmentation matches target RTP
         bm_rtp = bm.get_rtp()


### PR DESCRIPTION
This assertion would pass no matter what as long as dist_keys was not empty.
I assume it needs to 1:1 match the condition keys, so I fixed that.
____________________
_On a side note_: I'm not sure why the optimization config conditions has to ATLEAST define conditions/fences that match the names of the simulation distributions. Are the distributions not just a way to populate simulations with specific conditions/properties? The simulation distributions and the optimization conditions/fences seem like two completely unrelated things. If I have understood how the optimizer works correctly, it doesn't require a fence for every simulation distribution. I think the developer shouldn't be enforced to make a fence for every distribution. It may be natural to do so, but this just seems like an unnecessary limitation.

Please correct me if there is something I have misunderstood.