### PR TITLE
fix: only one win event emits from scattergame per win

### DIFF
--- a/games/0_0_scatter/game_executables.py
+++ b/games/0_0_scatter/game_executables.py
@@ -57,7 +57,6 @@ class GameExecutables(GameCalculations):
         Scatter.record_scatter_wins(self)
         self.win_manager.tumble_win = self.win_data["totalWin"]
         self.win_manager.update_spinwin(self.win_data["totalWin"])  # Update wallet
-        self.emit_tumble_win_events()  # Transmit win information
 
     def update_freespin(self) -> None:
         """Called before a new reveal during freegame."""

--- a/games/0_0_scatter/gamestate.py
+++ b/games/0_0_scatter/gamestate.py
@@ -18,6 +18,7 @@ class GameState(GameStateOverride):
             while self.win_data["totalWin"] > 0 and not (self.wincap_triggered):
                 self.tumble_game_board()
                 self.get_scatterpays_update_wins()
+                self.emit_tumble_win_events()  # Transmit win information
 
             self.set_end_tumble_event()
             self.win_manager.update_gametype_wins(self.gametype)
@@ -43,7 +44,9 @@ class GameState(GameStateOverride):
             while self.win_data["totalWin"] > 0 and not (self.wincap_triggered):
                 self.tumble_game_board()
                 self.update_global_mult()  # Special mechanic - increase multiplier with every tumble
+                
                 self.get_scatterpays_update_wins()
+                self.emit_tumble_win_events()  # Transmit win information
 
             self.set_end_tumble_event()
             self.win_manager.update_gametype_wins(self.gametype)


### PR DESCRIPTION
The scatter game example would emit two winInfo (and updateTumbleWin) events in a row of the first scatter-hit. This is because emit_tumble_win_events was also being called inside the get_scatterpays_update_wins.

To make it similar to the cluster example, I removed emit_tumble_win_events from the get_scatterpays_update_wins method and explicitally call it after the get_scatterpays_update_wins inside the tumbling loop.