### PR TITLE
force add symbols to board

### DIFF
--- a/src/state/state.py
+++ b/src/state/state.py
@@ -67,7 +67,7 @@ class GeneralGameState(ABC):
         self.board = [[[] for _ in range(self.config.num_rows[x])] for x in range(self.config.num_reels)]
         self.top_symbols = None
         self.bottom_symbols = None
-        self.book_id = self.sim + 1
+        self.book_id = self.sim
         self.book = Book(self.book_id, self.criteria)
         self.win_data = {
             "totalWin": 0,


### PR DESCRIPTION
Helper functions to add a specific number of symbols to a game board after drawing
Helper function to get reel-row positions of symbols, searched by name

Index self.book_id to 0 instead of 1. This is to match with the RGS replay-feature, which expects an 'event-id', corresponding to a 0-indexed row number in the lookup-table.

Example usage:
```
  additional_scatters = 0
  if self.get_current_distribution_conditions()["force_freegame"]:
      required_num_scatters = 6
      additional_scatters = max(required_num_scatters - self.count_symbols_on_board("S"), 0)
  if additional_scatters > 0:
      self.add_symbols_to_board("S", additional_scatters)
```
