### PR TITLE
Fix json_ready_sym to serialize actual attribute values

### DIFF
--- a/src/events/events.py
+++ b/src/events/events.py
@@ -11,7 +11,7 @@ def json_ready_sym(symbol: object, special_attributes: list = None):
 
     for attr in special_attributes:
         if hasattr(symbol, attr) and getattr(symbol, attr):
-            print_sym[attr] = True
+            print_sym[attr] = getattr(symbol, attr)
         elif attr in symbol.defn.special_flags:
             print_sym[attr] = True
 


### PR DESCRIPTION
- Changed line 14 to use getattr(symbol, attr) instead of hardcoding True
- Fixes data loss for numerical attributes like multiplier
- Closes #90